### PR TITLE
fix(ci): recreate &quot;Latest build&quot; release each run to bypass immutable releases

### DIFF
--- a/.github/workflows/latest-build.yml
+++ b/.github/workflows/latest-build.yml
@@ -53,6 +53,11 @@ jobs:
           echo "apk_path=$dest" >> "$GITHUB_OUTPUT"
           echo "short_sha=$short_sha" >> "$GITHUB_OUTPUT"
 
+      - name: Delete previous "latest-build" release
+        run: gh release delete latest-build --yes --cleanup-tag --repo "$GITHUB_REPOSITORY" || true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Publish to "Latest build" release
         uses: softprops/action-gh-release@v2
         with:


### PR DESCRIPTION
## Summary

The `latest-build` release publishes once and is then immutable, so the next run can't replace its APK and the workflow fails with:

> Cannot upload asset LibreTune-latest-….apk to an immutable release. GitHub only allows asset uploads before a release is published…

This adds a step that deletes the previous `latest-build` release **and** its tag before the publish step runs, so every run creates a fresh release with the new APK. The delete is best-effort (`|| true`) to keep the very first run — when no `latest-build` release exists yet — from failing.

## Test plan

- [ ] Trigger the workflow via `workflow_dispatch`; the delete step succeeds (or no-ops on first run) and the publish step uploads the APK.
- [ ] Push a follow-up commit and confirm the previous release is replaced rather than failing the upload.
- [ ] Verify only one `latest-build` release/tag exists in the Releases UI after each run.


---
_Generated by [Claude Code](https://claude.ai/code/session_01M8XPuq2R5WRCem8W6z9E4z)_