### PR TITLE
ci: publish APK as workflow artifact instead of GitHub release

### DIFF
--- a/.github/workflows/latest-build.yml
+++ b/.github/workflows/latest-build.yml
@@ -7,16 +7,13 @@ on:
       - master
   workflow_dispatch:
 
-permissions:
-  contents: write
-
 concurrency:
   group: latest-build
   cancel-in-progress: true
 
 jobs:
   build:
-    name: Build & publish APK
+    name: Build APK
     runs-on: ubuntu-latest
 
     steps:
@@ -53,23 +50,10 @@ jobs:
           echo "apk_path=$dest" >> "$GITHUB_OUTPUT"
           echo "short_sha=$short_sha" >> "$GITHUB_OUTPUT"
 
-      - name: Delete previous "latest-build" release
-        run: gh release delete latest-build --yes --cleanup-tag --repo "$GITHUB_REPOSITORY" || true
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Publish to "Latest build" release
-        uses: softprops/action-gh-release@v2
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v4
         with:
-          tag_name: latest-build
-          name: Latest build
-          body: |
-            Automated build from `${{ github.ref_name }}` @ `${{ steps.collect.outputs.short_sha }}`.
-
-            This release is updated on every push to the default branch and
-            always points to the most recent successful build.
-          prerelease: true
-          make_latest: false
-          files: ${{ steps.collect.outputs.apk_path }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          name: LibreTune-latest-${{ steps.collect.outputs.short_sha }}
+          path: ${{ steps.collect.outputs.apk_path }}
+          if-no-files-found: error
+          retention-days: 90


### PR DESCRIPTION
## Summary

Switches the `Latest Build` workflow from publishing a rolling GitHub Release to uploading the APK as a workflow artifact.

The repo has both **immutable releases** and a **"Restrict creations"** tag ruleset, which together make a rolling release impossible from CI: once `latest-build` was published, the tag name is permanently reserved (`tag_name was used by an immutable release`), and the workflow's `GITHUB_TOKEN` isn't allowed to create a fresh tag (`Cannot create ref due to creations being restricted`). Rather than fight those policies, this just hands the APK back as a build artifact — no tags, no releases, no friction. Frozen versions can be cut manually from any commit when desired.

### What changed
- Replaced the `softprops/action-gh-release@v2` step with `actions/upload-artifact@v4`.
- Dropped `permissions: contents: write` (no longer needed without release publishing).
- Renamed the job from "Build & publish APK" to "Build APK".
- Artifact is named `LibreTune-latest-<short_sha>` and retained for 90 days.

### How to download the APK after this lands
Open the workflow run on the **Actions** tab → scroll to the **Artifacts** section at the bottom → click the artifact to download a zip containing the APK.

## Test plan

- [ ] Trigger via `workflow_dispatch`; the run completes without needing release/tag permissions.
- [ ] The Actions run page shows a `LibreTune-latest-<sha>` artifact in the Artifacts section.
- [ ] Downloading the artifact yields a valid debug APK that installs on a device.
- [ ] No new releases or tags appear in the repo as a side effect of the run.


---
_Generated by [Claude Code](https://claude.ai/code/session_01M8XPuq2R5WRCem8W6z9E4z)_