### PR TITLE
Add backend Docker image build/publish and Portainer stack

### DIFF
--- a/.github/workflows/latest-build.yml
+++ b/.github/workflows/latest-build.yml
@@ -58,3 +58,44 @@ jobs:
           path: ${{ steps.collect.outputs.apk_path }}
           if-no-files-found: error
           retention-days: 90
+
+  publish-backend:
+    name: Build & Publish Backend Docker Image
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}/django-server
+          tags: |
+            type=raw,value=main,enable={{is_default_branch}}
+            type=sha,prefix=sha-,format=short
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./backend
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,4 +1,4 @@
 DJANGO_SECRET_KEY=change-me
 DJANGO_DEBUG=False
 DJANGO_ALLOWED_HOSTS=libretune.coluzziandrea.com,localhost,127.0.0.1
-DATABASE_URL=sqlite:///db.sqlite3
+DATABASE_URL=postgres://libretune_user:change-me@localhost:5432/libretune_db

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libpq-dev gcc \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+RUN python manage.py collectstatic --noinput
+
+EXPOSE 8000
+
+CMD ["gunicorn", "libretune_backend.wsgi:application", "--bind", "0.0.0.0:8000"]

--- a/backend/README.md
+++ b/backend/README.md
@@ -10,8 +10,16 @@ The service is deployed at https://libretune.coluzziandrea.com.
 
 ## Quickstart
 
+Start the local PostgreSQL instance first:
+
 ```bash
 cd backend
+docker compose -f docker-compose.dev.yml up -d
+```
+
+Then run the Django server:
+
+```bash
 python -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt

--- a/backend/docker-compose.dev.yml
+++ b/backend/docker-compose.dev.yml
@@ -1,0 +1,16 @@
+services:
+  db:
+    image: postgres:15-alpine
+    container_name: libretune-db-dev
+    restart: unless-stopped
+    environment:
+      - POSTGRES_DB=libretune_db
+      - POSTGRES_USER=libretune_user
+      - POSTGRES_PASSWORD=change-me
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+volumes:
+  postgres_data:

--- a/backend/libretune_backend/settings.py
+++ b/backend/libretune_backend/settings.py
@@ -60,10 +60,7 @@ TEMPLATES = [
 WSGI_APPLICATION = "libretune_backend.wsgi.application"
 
 DATABASES = {
-    "default": env.db(
-        "DATABASE_URL",
-        default=f"sqlite:///{BASE_DIR / 'db.sqlite3'}",
-    ),
+    "default": env.db("DATABASE_URL"),
 }
 
 AUTH_PASSWORD_VALIDATORS = [

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,3 +2,4 @@ Django>=5.0,<6.0
 djangorestframework>=3.15,<4.0
 django-environ>=0.11,<1.0
 gunicorn>=22.0,<24.0
+psycopg2-binary>=2.9,<3.0

--- a/portainer.yaml
+++ b/portainer.yaml
@@ -1,0 +1,66 @@
+version: '3.8'
+
+services:
+  db:
+    image: postgres:15-alpine
+    container_name: libretune-db
+    restart: unless-stopped
+    environment:
+      - POSTGRES_DB=libretune_db
+      - POSTGRES_USER=libretune_user
+      - POSTGRES_PASSWORD=${DB_PASSWORD}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U libretune_user -d libretune_db']
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  libretune-server:
+    image: ghcr.io/acoluzzi/libre-tune/django-server:main
+    container_name: libretune-server
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      - POSTGRES_HOST=db
+      - POSTGRES_DB=libretune_db
+      - POSTGRES_USER=libretune_user
+      - POSTGRES_PASSWORD=${DB_PASSWORD}
+      - POSTGRES_PORT=5432
+      - DJANGO_SECRET_KEY=${DJANGO_SECRET_KEY}
+      - DJANGO_ALLOWED_HOSTS=${DJANGO_ALLOWED_HOSTS}
+      - DATABASE_URL=postgres://libretune_user:${DB_PASSWORD}@db:5432/libretune_db
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.libretune.rule=Host(`${DOMAIN}`)"
+      - "traefik.http.services.libretune.loadbalancer.server.port=8000"
+      - "traefik.http.middlewares.libretune-ratelimit.ratelimit.average=60"
+      - "traefik.http.middlewares.libretune-ratelimit.ratelimit.burst=20"
+      - "traefik.http.routers.libretune.middlewares=libretune-ratelimit"
+    networks:
+      - default
+      - proxy
+    command: sh -c "python manage.py migrate --noinput && gunicorn libretune_backend.wsgi:application --bind 0.0.0.0:8000"
+
+  watchtower:
+    image: containrrr/watchtower
+    restart: unless-stopped
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      - WATCHTOWER_POLL_INTERVAL=60
+      - WATCHTOWER_CLEANUP=true
+      - WATCHTOWER_INCLUDE_STOPPED=false
+      - REPO_USER=${GHCR_USER}
+      - REPO_PASS=${GHCR_TOKEN}
+    command: libretune-server
+
+volumes:
+  postgres_data:
+
+networks:
+  proxy:
+    external: true


### PR DESCRIPTION
- Add backend/Dockerfile for Django/gunicorn image
- Add psycopg2-binary to requirements for PostgreSQL support
- Add publish-backend CI job that builds and pushes to GHCR on main
- Add portainer.yaml with postgres, libretune-server, and watchtower services

https://claude.ai/code/session_01SA2DBK7doWnaEfJKRR2yL2