### PR TITLE
feat: two-way YouTube Music playlist sync

### DIFF
--- a/app/src/main/java/com/colux/libretune/data/local/AppDatabase.kt
+++ b/app/src/main/java/com/colux/libretune/data/local/AppDatabase.kt
@@ -3,6 +3,8 @@ package com.colux.libretune.data.local
 import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 import com.colux.libretune.data.local.dao.ArtistDao
 import com.colux.libretune.data.local.dao.HistoryDao
 import com.colux.libretune.data.local.dao.LibraryDao
@@ -38,7 +40,7 @@ import com.colux.libretune.data.local.join.SongArtistCrossRef
         PlaybackHistoryEntity::class,
         LibraryEntity::class,
         HistoryArtistCrossRef::class,
-        PlaylistSongCrossRef::class], version = 1
+        PlaylistSongCrossRef::class], version = 2
 )
 @TypeConverters(Converters::class)
 abstract class AppDatabase : RoomDatabase() {
@@ -53,4 +55,17 @@ abstract class AppDatabase : RoomDatabase() {
 
     abstract fun libraryDao(): LibraryDao
     abstract fun historyDao(): HistoryDao
+
+    companion object {
+        val MIGRATION_1_2 = object : Migration(1, 2) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE playlists ADD COLUMN remotePlaylistId TEXT")
+                db.execSQL("ALTER TABLE playlists ADD COLUMN syncEnabled INTEGER NOT NULL DEFAULT 0")
+                db.execSQL("ALTER TABLE playlist_song_cross_ref ADD COLUMN setVideoId TEXT")
+                db.execSQL(
+                    "ALTER TABLE playlist_song_cross_ref ADD COLUMN syncState TEXT NOT NULL DEFAULT 'SYNCED'"
+                )
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/colux/libretune/data/local/Converters.kt
+++ b/app/src/main/java/com/colux/libretune/data/local/Converters.kt
@@ -4,6 +4,7 @@ import androidx.room.TypeConverter
 import com.colux.libretune.data.local.entity.AlbumType
 import com.colux.libretune.data.local.entity.ImageAttribute
 import com.colux.libretune.data.local.entity.LibraryItemType
+import com.colux.libretune.data.local.join.PlaylistSongSyncState
 import kotlinx.serialization.json.Json
 
 class Converters {
@@ -30,4 +31,11 @@ class Converters {
 
     @TypeConverter
     fun toLibraryType(name: String): LibraryItemType = LibraryItemType.valueOf(name)
+
+    @TypeConverter
+    fun fromPlaylistSongSyncState(state: PlaylistSongSyncState): String = state.name
+
+    @TypeConverter
+    fun toPlaylistSongSyncState(name: String): PlaylistSongSyncState =
+        PlaylistSongSyncState.valueOf(name)
 }

--- a/app/src/main/java/com/colux/libretune/data/local/DatabaseModule.kt
+++ b/app/src/main/java/com/colux/libretune/data/local/DatabaseModule.kt
@@ -32,7 +32,10 @@ object DatabaseModule {
             context,
             AppDatabase::class.java,
             "libretune_db"
-        ).addCallback(callback).build()
+        )
+            .addCallback(callback)
+            .addMigrations(AppDatabase.MIGRATION_1_2)
+            .build()
     }
 
     @Provides

--- a/app/src/main/java/com/colux/libretune/data/local/dao/PlaylistDao.kt
+++ b/app/src/main/java/com/colux/libretune/data/local/dao/PlaylistDao.kt
@@ -12,6 +12,7 @@ import com.colux.libretune.data.local.join.ArtistPlaylistCrossRef
 import com.colux.libretune.data.local.join.PlaylistArtistCrossRef
 import com.colux.libretune.data.local.join.PlaylistRelatedCrossRef
 import com.colux.libretune.data.local.join.PlaylistSongCrossRef
+import com.colux.libretune.data.local.join.PlaylistSongSyncState
 import com.colux.libretune.data.local.wrapper.PlaylistWithArtists
 import com.colux.libretune.data.local.wrapper.PlaylistWithSongsEntity
 import kotlinx.coroutines.flow.Flow
@@ -209,9 +210,12 @@ interface PlaylistDao {
 
     @Query(
         """
-       DELETE FROM playlist_song_cross_ref 
-          WHERE songId = :songId 
-            AND playlistId IN (SELECT playlistId FROM playlists WHERE isLocal = 1)
+       DELETE FROM playlist_song_cross_ref
+          WHERE songId = :songId
+            AND playlistId IN (
+                SELECT playlistId FROM playlists
+                WHERE isLocal = 1 AND syncEnabled = 0
+            )
     """
     )
     suspend fun removeSongFromAllLocalPlaylists(songId: String)
@@ -224,4 +228,62 @@ interface PlaylistDao {
     suspend fun removeSongFromPlaylist(join: PlaylistSongCrossRef)
 
 
+    // --- YouTube Music sync helpers ---
+
+    @Query(
+        """
+        UPDATE playlists
+        SET remotePlaylistId = :remotePlaylistId, syncEnabled = 1
+        WHERE playlistId = :playlistId
+    """
+    )
+    suspend fun markPlaylistSynced(playlistId: String, remotePlaylistId: String)
+
+    @Query(
+        """
+        UPDATE playlists
+        SET remotePlaylistId = NULL, syncEnabled = 0
+        WHERE playlistId = :playlistId
+    """
+    )
+    suspend fun markPlaylistUnsynced(playlistId: String)
+
+    @Query("SELECT * FROM playlists WHERE syncEnabled = 1")
+    fun getSyncedPlaylists(): Flow<List<PlaylistEntity>>
+
+    @Query("SELECT playlistId FROM playlists WHERE remotePlaylistId = :remotePlaylistId LIMIT 1")
+    suspend fun getLocalIdByRemoteId(remotePlaylistId: String): String?
+
+    @Query("SELECT * FROM playlist_song_cross_ref WHERE playlistId = :playlistId AND songId = :songId LIMIT 1")
+    suspend fun getCrossRef(playlistId: String, songId: String): PlaylistSongCrossRef?
+
+    @Query(
+        """
+        SELECT * FROM playlist_song_cross_ref
+        WHERE playlistId = :playlistId AND syncState != 'SYNCED'
+    """
+    )
+    suspend fun getPendingSyncEntries(playlistId: String): List<PlaylistSongCrossRef>
+
+    @Query(
+        """
+        UPDATE playlist_song_cross_ref
+        SET setVideoId = :setVideoId, syncState = :state
+        WHERE playlistId = :playlistId AND songId = :songId
+    """
+    )
+    suspend fun updateCrossRefSyncState(
+        playlistId: String,
+        songId: String,
+        setVideoId: String?,
+        state: PlaylistSongSyncState
+    )
+
+    @Query(
+        """
+        SELECT songId FROM playlist_song_cross_ref
+        WHERE playlistId = :playlistId
+    """
+    )
+    suspend fun getSongIdsInPlaylist(playlistId: String): List<String>
 }

--- a/app/src/main/java/com/colux/libretune/data/local/dao/SongDao.kt
+++ b/app/src/main/java/com/colux/libretune/data/local/dao/SongDao.kt
@@ -66,6 +66,9 @@ interface SongDao {
     @Query("SELECT * FROM songs WHERE songId = :id")
     fun getSongById(id: String): Flow<SongEntity?>
 
+    @Query("SELECT * FROM songs WHERE songId = :id")
+    suspend fun getSongByIdOnce(id: String): SongEntity?
+
 
     @Query(
         """

--- a/app/src/main/java/com/colux/libretune/data/local/entity/PlaylistEntity.kt
+++ b/app/src/main/java/com/colux/libretune/data/local/entity/PlaylistEntity.kt
@@ -13,5 +13,11 @@ data class PlaylistEntity(
     val type: AlbumType,
     val isLocal: Boolean? = false,
     val releaseYear: Int? = null,
-    val updateTimestamp: Long? = null
+    val updateTimestamp: Long? = null,
+    /**
+     * YouTube Music playlist ID this local playlist mirrors. Null for plain
+     * local playlists and for non-synced browsed playlists.
+     */
+    val remotePlaylistId: String? = null,
+    val syncEnabled: Boolean = false
 )

--- a/app/src/main/java/com/colux/libretune/data/local/join/PlaylistSongCrossRef.kt
+++ b/app/src/main/java/com/colux/libretune/data/local/join/PlaylistSongCrossRef.kt
@@ -2,8 +2,20 @@ package com.colux.libretune.data.local.join
 
 import androidx.room.Entity
 
+/**
+ * Sync state of a single song inside a synced playlist.
+ *
+ * - [SYNCED]: in step with YouTube Music.
+ * - [PENDING_ADD]: added locally, push to YT Music still owed.
+ * - [PENDING_REMOVE]: removed locally, delete-on-YT-Music still owed.
+ */
+enum class PlaylistSongSyncState { SYNCED, PENDING_ADD, PENDING_REMOVE }
+
 @Entity(tableName = "playlist_song_cross_ref", primaryKeys = ["playlistId", "songId"])
 data class PlaylistSongCrossRef(
     val playlistId: String,
-    val songId: String
+    val songId: String,
+    /** YT Music per-occurrence identifier; required to remove the row from YT Music. */
+    val setVideoId: String? = null,
+    val syncState: PlaylistSongSyncState = PlaylistSongSyncState.SYNCED
 )

--- a/app/src/main/java/com/colux/libretune/data/model/PlaylistDetails.kt
+++ b/app/src/main/java/com/colux/libretune/data/model/PlaylistDetails.kt
@@ -9,7 +9,9 @@ data class PlaylistDetails(
     val artists: List<Artist>,
     val songs: List<Song>,
     val relatedPlaylists: List<Playlist>,
-    val releaseYear: Int
+    val releaseYear: Int,
+    val syncEnabled: Boolean = false,
+    val remotePlaylistId: String? = null,
 ) {
     val totalDurationSeconds: Long
         get() = songs.sumOf { it.durationSec ?: 0L }

--- a/app/src/main/java/com/colux/libretune/data/remote/auth/YtMusicAuthRepository.kt
+++ b/app/src/main/java/com/colux/libretune/data/remote/auth/YtMusicAuthRepository.kt
@@ -1,0 +1,45 @@
+package com.colux.libretune.data.remote.auth
+
+import com.coluzziandrea.libretune_extractor.auth.AuthProvider
+import com.coluzziandrea.libretune_extractor.auth.YtmAuthState
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Single source of truth for YT Music auth state in the app.
+ *
+ * It both persists credentials (delegating to [YtMusicCredentialsStore]) and
+ * exposes itself as an [AuthProvider] so the extractor module can request the
+ * current state on every outgoing request without a Hilt dependency on app
+ * code.
+ */
+@Singleton
+class YtMusicAuthRepository @Inject constructor(
+    private val store: YtMusicCredentialsStore
+) : AuthProvider {
+
+    private val _state = MutableStateFlow(store.load())
+    val state: StateFlow<YtmAuthState?> = _state.asStateFlow()
+
+    fun signIn(cookieHeader: String, visitorData: String? = null) {
+        val sapisid = YtmAuthState.extractSapisid(cookieHeader)
+            ?: error("Could not find SAPISID cookie — sign-in did not complete")
+        val newState = YtmAuthState(
+            cookieHeader = cookieHeader,
+            sapisid = sapisid,
+            visitorData = visitorData
+        )
+        store.save(newState)
+        _state.value = newState
+    }
+
+    fun signOut() {
+        store.clear()
+        _state.value = null
+    }
+
+    override fun current(): YtmAuthState? = _state.value
+}

--- a/app/src/main/java/com/colux/libretune/data/remote/auth/YtMusicCredentialsStore.kt
+++ b/app/src/main/java/com/colux/libretune/data/remote/auth/YtMusicCredentialsStore.kt
@@ -1,0 +1,57 @@
+package com.colux.libretune.data.remote.auth
+
+import android.content.Context
+import android.content.SharedPreferences
+import com.coluzziandrea.libretune_extractor.auth.YtmAuthState
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Persists the YouTube Music session cookies on disk.
+ *
+ * Stored in plain `SharedPreferences` for now — the cookies are scoped to this
+ * app's data dir and don't leave the device, but moving to
+ * `EncryptedSharedPreferences` is a sensible hardening step before shipping.
+ */
+@Singleton
+class YtMusicCredentialsStore @Inject constructor(
+    @ApplicationContext context: Context
+) {
+    private val prefs: SharedPreferences =
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    fun save(state: YtmAuthState) {
+        prefs.edit()
+            .putString(KEY_COOKIE, state.cookieHeader)
+            .putString(KEY_SAPISID, state.sapisid)
+            .putString(KEY_ORIGIN, state.origin)
+            .putString(KEY_VISITOR_DATA, state.visitorData)
+            .apply()
+    }
+
+    fun load(): YtmAuthState? {
+        val cookie = prefs.getString(KEY_COOKIE, null) ?: return null
+        val sapisid = prefs.getString(KEY_SAPISID, null)
+            ?: YtmAuthState.extractSapisid(cookie)
+            ?: return null
+        return YtmAuthState(
+            cookieHeader = cookie,
+            sapisid = sapisid,
+            origin = prefs.getString(KEY_ORIGIN, "https://music.youtube.com")!!,
+            visitorData = prefs.getString(KEY_VISITOR_DATA, null)
+        )
+    }
+
+    fun clear() {
+        prefs.edit().clear().apply()
+    }
+
+    companion object {
+        private const val PREFS_NAME = "ytm_auth"
+        private const val KEY_COOKIE = "cookie"
+        private const val KEY_SAPISID = "sapisid"
+        private const val KEY_ORIGIN = "origin"
+        private const val KEY_VISITOR_DATA = "visitor_data"
+    }
+}

--- a/app/src/main/java/com/colux/libretune/data/repository/PlaylistRepository.kt
+++ b/app/src/main/java/com/colux/libretune/data/repository/PlaylistRepository.kt
@@ -41,6 +41,7 @@ import javax.inject.Singleton
 class PlaylistRepository @Inject constructor(
     private val remote: YouTubeExtractionRepository,
     private val db: AppDatabase,
+    private val sync: YouTubeMusicSyncRepository,
 ) {
     companion object {
         private const val MAX_RELATED_FOR_PLAYLIST = 10
@@ -101,9 +102,10 @@ class PlaylistRepository @Inject constructor(
         }
     }
 
-    suspend fun createNewPlaylist(name: String) {
+    suspend fun createNewPlaylist(name: String, syncWithYouTubeMusic: Boolean = false): String {
+        val localId = "local-${System.currentTimeMillis()}"
         val newPlaylist = PlaylistEntity(
-            playlistId = "local-${System.currentTimeMillis()}",
+            playlistId = localId,
             name = name,
             images = emptyList(),
             isLocal = true,
@@ -111,6 +113,23 @@ class PlaylistRepository @Inject constructor(
             updateTimestamp = System.currentTimeMillis()
         )
         db.playlistDao().insert(newPlaylist)
+
+        if (syncWithYouTubeMusic && sync.isSignedIn) {
+            sync.enableSyncForPlaylist(localId)
+                .onFailure { logger.log(Level.WARNING, "Failed to enable sync for $localId", it) }
+        }
+        return localId
+    }
+
+    suspend fun enableSyncForPlaylist(localId: String): Result<String> =
+        sync.enableSyncForPlaylist(localId)
+
+    suspend fun disableSyncForPlaylist(localId: String, alsoDeleteRemote: Boolean) {
+        sync.disableSyncForPlaylist(localId, alsoDeleteRemote)
+    }
+
+    suspend fun pullPlaylistFromYouTubeMusic(localId: String) {
+        sync.pullFromYouTubeMusic(localId)
     }
 
 
@@ -170,7 +189,9 @@ class PlaylistRepository @Inject constructor(
                     songs = songs.map { it.toDataModel() }.sortedBy { it.trackNumber },
                     relatedPlaylists = related.map { it.toDataModel() },
                     isLocal = playlistWithArtists.playlist.isLocal ?: false,
-                    releaseYear = playlistWithArtists.playlist.releaseYear ?: 0
+                    releaseYear = playlistWithArtists.playlist.releaseYear ?: 0,
+                    syncEnabled = playlistWithArtists.playlist.syncEnabled,
+                    remotePlaylistId = playlistWithArtists.playlist.remotePlaylistId
                 )
             }
         }
@@ -227,6 +248,15 @@ class PlaylistRepository @Inject constructor(
     suspend fun refreshPlaylistDetails(id: String) {
 
         logger.info { "Starting refreshPlaylistDetails for $id" }
+
+        // For synced local playlists, pulling from YT Music is the right
+        // "refresh" — we ignore the standard remote-fetch path entirely.
+        val cached = db.playlistDao().getPlaylistById(id)
+        if (cached?.syncEnabled == true) {
+            sync.pullFromYouTubeMusic(id)
+            return
+        }
+
         if (shouldFetch(id)) {
             logger.info { "Fetching data from remote" }
             updatePlaylistDetailsFromRemote(id)

--- a/app/src/main/java/com/colux/libretune/data/repository/SongRepository.kt
+++ b/app/src/main/java/com/colux/libretune/data/repository/SongRepository.kt
@@ -23,6 +23,7 @@ import javax.inject.Singleton
 class SongRepository @Inject constructor(
     private val remote: YouTubeExtractionRepository,
     private val db: AppDatabase,
+    private val sync: YouTubeMusicSyncRepository,
 ) {
 
     private val logger = java.util.logging.Logger.getLogger(SongRepository::class.java.name)
@@ -165,15 +166,36 @@ class SongRepository @Inject constructor(
     }
 
     suspend fun removeSongFromAllPlaylists(songId: String) {
+        // Mirror removal for every synced playlist this song lives in.
+        // mirrorRemoveSong leaves the local cross-ref in place as
+        // PENDING_REMOVE if YT Music rejected the call, so the wipe at the
+        // end only drops cross-refs whose remote side actually succeeded.
+        val syncedHostingPlaylists = db.playlistDao()
+            .getSyncedPlaylists()
+            .firstOrNull()
+            .orEmpty()
+            .filter { it.isLocal == true }
+        for (p in syncedHostingPlaylists) {
+            val ref = db.playlistDao().getCrossRef(p.playlistId, songId) ?: continue
+            val canDeleteLocally = sync.mirrorRemoveSong(p.playlistId, songId)
+            if (canDeleteLocally) {
+                db.playlistDao().removeSongFromPlaylist(ref)
+            }
+        }
+        // Non-synced local playlists are always free to drop the row.
         db.playlistDao().removeSongFromAllLocalPlaylists(songId)
     }
 
     suspend fun removeSongFromPlaylist(playlistId: String, songId: String) {
-        db.playlistDao().removeSongFromPlaylist(PlaylistSongCrossRef(playlistId, songId))
+        val canDeleteLocally = sync.mirrorRemoveSong(playlistId, songId)
+        if (canDeleteLocally) {
+            db.playlistDao().removeSongFromPlaylist(PlaylistSongCrossRef(playlistId, songId))
+        }
     }
 
     suspend fun addSongToPlaylist(playlistId: String, song: Song) {
         _addSongToPlaylist(playlistId, song)
+        sync.mirrorAddSong(playlistId, song.id)
     }
 
 

--- a/app/src/main/java/com/colux/libretune/data/repository/YouTubeMusicSyncRepository.kt
+++ b/app/src/main/java/com/colux/libretune/data/repository/YouTubeMusicSyncRepository.kt
@@ -1,0 +1,299 @@
+package com.colux.libretune.data.repository
+
+import androidx.room.withTransaction
+import com.coluzziandrea.libretune_extractor.LibreTuneExtractor
+import com.coluzziandrea.libretune_extractor.sync.RemotePlaylistSnapshot
+import com.colux.libretune.data.local.AppDatabase
+import com.colux.libretune.data.local.join.PlaylistSongCrossRef
+import com.colux.libretune.data.local.join.PlaylistSongSyncState
+import com.colux.libretune.data.remote.auth.YtMusicAuthRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
+import java.util.logging.Level
+import java.util.logging.Logger
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Orchestrates two-way sync between local playlists and YouTube Music.
+ *
+ * Local-DB writes happen instantly so the UI is never blocked on the network;
+ * remote mutations are best-effort and recorded as `PENDING_*` rows when they
+ * fail, so a later push/pull can reconcile them.
+ */
+@Singleton
+class YouTubeMusicSyncRepository @Inject constructor(
+    private val db: AppDatabase,
+    private val extractor: LibreTuneExtractor,
+    private val auth: YtMusicAuthRepository,
+) {
+
+    private val logger = Logger.getLogger("YouTubeMusicSyncRepository")
+
+    val isSignedIn: Boolean
+        get() = auth.current() != null
+
+    /**
+     * Promotes a plain local playlist to a synced playlist: create the mirror
+     * on YouTube Music, then push every existing local song into it.
+     */
+    suspend fun enableSyncForPlaylist(localPlaylistId: String): Result<String> = runCatching {
+        require(isSignedIn) { "Not signed in to YouTube Music" }
+        val local = db.playlistDao().getPlaylistById(localPlaylistId)
+            ?: error("Playlist $localPlaylistId not found")
+        require(local.isLocal == true) {
+            "Only local playlists can be promoted to synced playlists"
+        }
+
+        val remoteId = withContext(Dispatchers.IO) {
+            extractor.sync.createPlaylist(
+                title = local.name,
+                description = "Synced from LibreTune"
+            )
+        } ?: error("YouTube Music did not return a playlist ID")
+
+        db.playlistDao().markPlaylistSynced(localPlaylistId, remoteId)
+
+        // Push every existing song so the remote playlist matches local.
+        val songIds = db.playlistDao().getSongIdsInPlaylist(localPlaylistId)
+        for (songId in songIds) {
+            mirrorAddSong(localPlaylistId, songId)
+        }
+        remoteId
+    }
+
+    suspend fun disableSyncForPlaylist(localPlaylistId: String, alsoDeleteRemote: Boolean) {
+        val local = db.playlistDao().getPlaylistById(localPlaylistId) ?: return
+        val remoteId = local.remotePlaylistId
+
+        if (alsoDeleteRemote && remoteId != null && isSignedIn) {
+            withContext(Dispatchers.IO) {
+                runCatching { extractor.sync.deletePlaylist(remoteId) }
+                    .onFailure { logger.log(Level.WARNING, "Failed to delete remote playlist", it) }
+            }
+        }
+
+        db.playlistDao().markPlaylistUnsynced(localPlaylistId)
+    }
+
+    /**
+     * Mirror a local "add song" to YouTube Music. Safe to call regardless of
+     * sync state — it's a no-op for non-synced playlists.
+     *
+     * The cross-ref must already exist (the caller inserted it). On failure
+     * the cross-ref is marked `PENDING_ADD` so a future push can retry.
+     */
+    suspend fun mirrorAddSong(localPlaylistId: String, songId: String) {
+        val playlist = db.playlistDao().getPlaylistById(localPlaylistId) ?: return
+        if (!playlist.syncEnabled) return
+        val remoteId = playlist.remotePlaylistId ?: return
+        if (!isSignedIn) {
+            markPending(localPlaylistId, songId, PlaylistSongSyncState.PENDING_ADD)
+            return
+        }
+
+        try {
+            val setVideoId = withContext(Dispatchers.IO) {
+                extractor.sync.addToPlaylist(remoteId, songId)
+            }
+            db.playlistDao().updateCrossRefSyncState(
+                playlistId = localPlaylistId,
+                songId = songId,
+                setVideoId = setVideoId,
+                state = PlaylistSongSyncState.SYNCED
+            )
+        } catch (e: Exception) {
+            logger.log(Level.WARNING, "mirrorAddSong failed for $songId", e)
+            markPending(localPlaylistId, songId, PlaylistSongSyncState.PENDING_ADD)
+        }
+    }
+
+    /**
+     * Mirror a local "remove song" to YouTube Music and delete the local
+     * cross-ref if the remote call succeeded.
+     *
+     * Returns `true` when the caller may consider the row gone (either it was
+     * never synced, or the YT Music call succeeded). Returns `false` when the
+     * row was kept as `PENDING_REMOVE` because the remote call failed — the
+     * caller MUST leave the local cross-ref in place so the next push can
+     * retry.
+     */
+    suspend fun mirrorRemoveSong(localPlaylistId: String, songId: String): Boolean {
+        val playlist = db.playlistDao().getPlaylistById(localPlaylistId) ?: return true
+        if (!playlist.syncEnabled) return true
+        val remoteId = playlist.remotePlaylistId ?: return true
+
+        val crossRef = db.playlistDao().getCrossRef(localPlaylistId, songId) ?: return true
+
+        // If the song was never successfully pushed, there's nothing to delete
+        // remotely — local delete is enough.
+        if (crossRef.syncState == PlaylistSongSyncState.PENDING_ADD || crossRef.setVideoId == null) {
+            return true
+        }
+
+        if (!isSignedIn) {
+            db.playlistDao().updateCrossRefSyncState(
+                playlistId = localPlaylistId,
+                songId = songId,
+                setVideoId = crossRef.setVideoId,
+                state = PlaylistSongSyncState.PENDING_REMOVE
+            )
+            return false
+        }
+
+        return try {
+            withContext(Dispatchers.IO) {
+                extractor.sync.removeFromPlaylist(remoteId, songId, crossRef.setVideoId)
+            }
+            true
+        } catch (e: Exception) {
+            logger.log(Level.WARNING, "mirrorRemoveSong failed for $songId", e)
+            db.playlistDao().updateCrossRefSyncState(
+                playlistId = localPlaylistId,
+                songId = songId,
+                setVideoId = crossRef.setVideoId,
+                state = PlaylistSongSyncState.PENDING_REMOVE
+            )
+            false
+        }
+    }
+
+    /**
+     * Pull the canonical state of the remote playlist into the local DB.
+     *
+     * Reconciliation rules:
+     * - Songs only in remote → inserted locally (and looked up via extractor for metadata).
+     * - Songs only in local with `PENDING_ADD` → pushed to remote.
+     * - Songs only in local with `PENDING_REMOVE` → removal pushed to remote, then deleted locally.
+     * - Songs in both → `setVideoId` refreshed.
+     */
+    suspend fun pullFromYouTubeMusic(localPlaylistId: String) {
+        val playlist = db.playlistDao().getPlaylistById(localPlaylistId) ?: return
+        if (!playlist.syncEnabled) return
+        val remoteId = playlist.remotePlaylistId ?: return
+        if (!isSignedIn) return
+
+        val snapshot: RemotePlaylistSnapshot = try {
+            withContext(Dispatchers.IO) { extractor.sync.fetchPlaylistItems(remoteId) }
+        } catch (e: Exception) {
+            logger.log(Level.WARNING, "Failed to pull playlist $remoteId", e)
+            return
+        }
+
+        val localSongIds = db.playlistDao().getSongIdsInPlaylist(localPlaylistId).toMutableSet()
+
+        // 1. Push pending local changes first so we don't clobber them on pull.
+        val pending = db.playlistDao().getPendingSyncEntries(localPlaylistId)
+        for (entry in pending) {
+            when (entry.syncState) {
+                PlaylistSongSyncState.PENDING_ADD -> mirrorAddSong(localPlaylistId, entry.songId)
+                PlaylistSongSyncState.PENDING_REMOVE -> {
+                    val pushed = mirrorRemoveSong(localPlaylistId, entry.songId)
+                    if (pushed) {
+                        db.playlistDao().removeSongFromPlaylist(entry)
+                        localSongIds.remove(entry.songId)
+                    }
+                }
+                PlaylistSongSyncState.SYNCED -> Unit
+            }
+        }
+
+        // 2. Mirror remote → local.
+        db.withTransaction {
+            for (remoteItem in snapshot.items) {
+                ensureSongStub(remoteItem.videoId, remoteItem.title)
+                db.playlistDao().addSongToPlaylist(
+                    PlaylistSongCrossRef(
+                        playlistId = localPlaylistId,
+                        songId = remoteItem.videoId,
+                        setVideoId = remoteItem.setVideoId,
+                        syncState = PlaylistSongSyncState.SYNCED
+                    )
+                )
+                localSongIds.remove(remoteItem.videoId)
+            }
+
+            // 3. Anything still in `localSongIds` is on the local side only and
+            //    not in PENDING_* (those were handled above) — meaning the user
+            //    removed it on YT Music. Drop the local row.
+            for (orphan in localSongIds) {
+                db.playlistDao().removeSongFromPlaylist(
+                    PlaylistSongCrossRef(
+                        playlistId = localPlaylistId,
+                        songId = orphan
+                    )
+                )
+            }
+
+            // 4. If YT Music renamed the playlist, mirror that too.
+            snapshot.title?.takeIf { it.isNotBlank() && it != playlist.name }?.let { newName ->
+                db.playlistDao().upsert(playlist.copy(name = newName))
+            }
+        }
+
+        logger.info {
+            "Pulled ${snapshot.items.size} items from YT Music playlist $remoteId " +
+                "into local $localPlaylistId"
+        }
+    }
+
+    /**
+     * Replays every pending mutation for every synced playlist. Useful to call
+     * after sign-in to drain offline-queued changes.
+     */
+    suspend fun flushPendingMutations() {
+        if (!isSignedIn) return
+        // Snapshot once — we don't want to subscribe.
+        val syncedPlaylists = db.playlistDao().getSyncedPlaylists().first()
+        for (p in syncedPlaylists) {
+            for (entry in db.playlistDao().getPendingSyncEntries(p.playlistId)) {
+                when (entry.syncState) {
+                    PlaylistSongSyncState.PENDING_ADD -> mirrorAddSong(p.playlistId, entry.songId)
+                    PlaylistSongSyncState.PENDING_REMOVE -> {
+                        if (mirrorRemoveSong(p.playlistId, entry.songId)) {
+                            db.playlistDao().removeSongFromPlaylist(entry)
+                        }
+                    }
+                    PlaylistSongSyncState.SYNCED -> Unit
+                }
+            }
+        }
+    }
+
+    private suspend fun markPending(
+        playlistId: String,
+        songId: String,
+        state: PlaylistSongSyncState
+    ) {
+        val existing = db.playlistDao().getCrossRef(playlistId, songId)
+        db.playlistDao().updateCrossRefSyncState(
+            playlistId = playlistId,
+            songId = songId,
+            setVideoId = existing?.setVideoId,
+            state = state
+        )
+    }
+
+    /**
+     * Materialise a placeholder song row when YT Music returned a track we
+     * don't yet know about. We try the full extractor lookup first; if that
+     * fails we drop in a stub so the cross-ref FK constraint is satisfied.
+     */
+    private suspend fun ensureSongStub(videoId: String, title: String?) {
+        val existing = db.songDao().getSongByIdOnce(videoId)
+        if (existing != null) return
+
+        val song = com.colux.libretune.data.local.entity.SongEntity(
+            songId = videoId,
+            title = title ?: "Unknown",
+            albumId = null,
+            trackNumber = null,
+            images = emptyList(),
+            views = 0,
+            durationSec = null,
+            updateTimestamp = System.currentTimeMillis()
+        )
+        db.songDao().insertSong(song)
+    }
+}

--- a/app/src/main/java/com/colux/libretune/di/AuthModule.kt
+++ b/app/src/main/java/com/colux/libretune/di/AuthModule.kt
@@ -1,0 +1,18 @@
+package com.colux.libretune.di
+
+import com.coluzziandrea.libretune_extractor.auth.AuthProvider
+import com.colux.libretune.data.remote.auth.YtMusicAuthRepository
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class AuthModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindAuthProvider(impl: YtMusicAuthRepository): AuthProvider
+}

--- a/app/src/main/java/com/colux/libretune/ui/create_playlist/CreatePlaylistScreen.kt
+++ b/app/src/main/java/com/colux/libretune/ui/create_playlist/CreatePlaylistScreen.kt
@@ -18,10 +18,12 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -39,6 +41,8 @@ fun CreatePlaylistScreen(
     viewModel: CreateNewPlaylistViewModel = hiltViewModel()
 ) {
     var text by remember { mutableStateOf("") }
+    var syncWithYouTubeMusic by remember { mutableStateOf(false) }
+    val isSignedIn by viewModel.isSignedInToYouTubeMusic.collectAsState()
 
     Scaffold(
         topBar = {
@@ -73,6 +77,34 @@ fun CreatePlaylistScreen(
                 modifier = Modifier.fillMaxWidth()
             )
 
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        "Sync with YouTube Music",
+                        style = MaterialTheme.typography.titleMedium
+                    )
+                    Text(
+                        if (isSignedIn) {
+                            "Songs you add here will mirror to your YT Music account."
+                        } else {
+                            "Sign in via the drawer's YouTube Music entry first."
+                        },
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
+                    )
+                }
+                Switch(
+                    checked = syncWithYouTubeMusic && isSignedIn,
+                    onCheckedChange = { syncWithYouTubeMusic = it },
+                    enabled = isSignedIn
+                )
+            }
+
             Spacer(modifier = Modifier.height(24.dp))
 
             Row(
@@ -87,7 +119,10 @@ fun CreatePlaylistScreen(
                 Button(
                     onClick = {
                         if (text.isNotBlank()) {
-                            viewModel.createPlaylist(text)
+                            viewModel.createPlaylist(
+                                name = text,
+                                syncWithYouTubeMusic = syncWithYouTubeMusic && isSignedIn
+                            )
                             navController.popBackStack()
                         }
                     },

--- a/app/src/main/java/com/colux/libretune/ui/create_playlist/CreatePlaylistViewModel.kt
+++ b/app/src/main/java/com/colux/libretune/ui/create_playlist/CreatePlaylistViewModel.kt
@@ -2,19 +2,36 @@ package com.colux.libretune.ui.create_playlist
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.colux.libretune.data.remote.auth.YtMusicAuthRepository
 import com.colux.libretune.data.repository.PlaylistRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class CreateNewPlaylistViewModel @Inject constructor(
-    private val playlistRepository: PlaylistRepository
+    private val playlistRepository: PlaylistRepository,
+    authRepository: YtMusicAuthRepository,
 ) : ViewModel() {
 
-    fun createPlaylist(name: String) {
+    val isSignedInToYouTubeMusic: StateFlow<Boolean> = authRepository.state
+        .map { it != null }
+        .stateIn(
+            viewModelScope,
+            SharingStarted.WhileSubscribed(5000),
+            authRepository.current() != null
+        )
+
+    fun createPlaylist(name: String, syncWithYouTubeMusic: Boolean) {
         viewModelScope.launch {
-            playlistRepository.createNewPlaylist(name)
+            playlistRepository.createNewPlaylist(
+                name = name,
+                syncWithYouTubeMusic = syncWithYouTubeMusic
+            )
         }
     }
 }

--- a/app/src/main/java/com/colux/libretune/ui/nav/AppDrawerMenu.kt
+++ b/app/src/main/java/com/colux/libretune/ui/nav/AppDrawerMenu.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CloudSync
 import androidx.compose.material.icons.filled.History
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -56,6 +57,20 @@ fun AppDrawerMenu(navController: NavController, closeDrawer: () -> Unit) {
                 icon = { Icon(Icons.Default.History, contentDescription = "History") },
                 selected = false,
                 onClick = { navController.navigate("history"); closeDrawer() }
+            )
+            NavigationDrawerItem(
+                label = { Text("YouTube Music") },
+                icon = {
+                    Icon(
+                        Icons.Default.CloudSync,
+                        contentDescription = "YouTube Music sync"
+                    )
+                },
+                selected = false,
+                onClick = {
+                    navController.navigate(Screen.YouTubeMusicSignIn.createRoute())
+                    closeDrawer()
+                }
             )
             // TODO add statistics and settings pages
 //            NavigationDrawerItem(

--- a/app/src/main/java/com/colux/libretune/ui/nav/Navigation.kt
+++ b/app/src/main/java/com/colux/libretune/ui/nav/Navigation.kt
@@ -18,6 +18,7 @@ import com.colux.libretune.ui.mood_genre.MoodGenreScreen
 import com.colux.libretune.ui.player.PlayerViewModel
 import com.colux.libretune.ui.playlist.PlaylistDetailScreen
 import com.colux.libretune.ui.search.SearchScreen
+import com.colux.libretune.ui.sign_in.YouTubeMusicSignInScreen
 
 @Composable
 fun Navigation(
@@ -234,6 +235,10 @@ fun Navigation(
 
             composable(Screen.History.route) {
                 HistoryScreen(navController = navController, playerViewModel = playerViewModel)
+            }
+
+            composable(Screen.YouTubeMusicSignIn.route) {
+                YouTubeMusicSignInScreen(navController = navController)
             }
         }
 

--- a/app/src/main/java/com/colux/libretune/ui/nav/Screen.kt
+++ b/app/src/main/java/com/colux/libretune/ui/nav/Screen.kt
@@ -3,6 +3,7 @@ package com.colux.libretune.ui.nav
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Album
+import androidx.compose.material.icons.filled.CloudSync
 import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Person
@@ -74,6 +75,16 @@ sealed class Screen(
     data object MoodGenre :
         Screen("mood_genre/{moodGenreId}", "Mood Genre", Icons.Default.Album, Icons.Default.Album) {
         fun createRoute(moodGenreId: String) = "mood_genre/$moodGenreId"
+    }
+
+    data object YouTubeMusicSignIn :
+        Screen(
+            "youtube_music_sign_in",
+            "YouTube Music",
+            Icons.Default.CloudSync,
+            Icons.Default.CloudSync
+        ) {
+        fun createRoute() = "youtube_music_sign_in"
     }
 
 }

--- a/app/src/main/java/com/colux/libretune/ui/playlist/PlaylistScreen.kt
+++ b/app/src/main/java/com/colux/libretune/ui/playlist/PlaylistScreen.kt
@@ -21,12 +21,18 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.CloudDone
+import androidx.compose.material.icons.filled.CloudOff
+import androidx.compose.material.icons.filled.CloudSync
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Shuffle
 import androidx.compose.material.icons.outlined.FavoriteBorder
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.Icon
@@ -96,6 +102,8 @@ fun PlaylistDetailScreen(
         initial = false
     )
 
+    val isSignedInToYouTubeMusic by viewModel.isSignedInToYouTubeMusic.collectAsState()
+
     when (val state = uiState) {
         is PlaylistUiState.Loading -> PlaylistDetailSkeleton()
         is PlaylistUiState.Success -> {
@@ -155,6 +163,14 @@ fun PlaylistDetailScreen(
                                     },
                                     onDislike = {
                                         viewModel.dislikePlaylist()
+                                    },
+                                    isSignedInToYouTubeMusic = isSignedInToYouTubeMusic,
+                                    onEnableSync = { viewModel.enableYouTubeMusicSync() },
+                                    onDisableSync = { deleteRemote ->
+                                        viewModel.disableYouTubeMusicSync(deleteRemote)
+                                    },
+                                    onRefreshFromRemote = {
+                                        viewModel.refreshFromYouTubeMusic()
                                     }
                                 )
                             }
@@ -276,8 +292,13 @@ fun PlaylistHeader(
     onPlayPauseClick: () -> Unit,
     onShuffleClick: () -> Unit,
     onLike: () -> Unit,
-    onDislike: () -> Unit
+    onDislike: () -> Unit,
+    isSignedInToYouTubeMusic: Boolean = false,
+    onEnableSync: () -> Unit = {},
+    onDisableSync: (deleteRemote: Boolean) -> Unit = {},
+    onRefreshFromRemote: () -> Unit = {},
 ) {
+    var menuOpen by remember { mutableStateOf(false) }
 
 
     Column(modifier = Modifier.padding(16.dp)) {
@@ -321,12 +342,25 @@ fun PlaylistHeader(
 
             Spacer(modifier = Modifier.width(16.dp))
             Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.Center) {
-                Text(
-                    details.name,
-                    style = MaterialTheme.typography.headlineSmall,
-                    modifier = Modifier.basicMarquee(),
-                    maxLines = 2
-                )
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        details.name,
+                        style = MaterialTheme.typography.headlineSmall,
+                        modifier = Modifier
+                            .weight(1f, fill = false)
+                            .basicMarquee(),
+                        maxLines = 2
+                    )
+                    if (details.syncEnabled) {
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Icon(
+                            Icons.Default.CloudDone,
+                            contentDescription = "Synced with YouTube Music",
+                            tint = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.size(20.dp)
+                        )
+                    }
+                }
 
                 if (details.artists.isNotEmpty()) {
                     Text(
@@ -374,8 +408,61 @@ fun PlaylistHeader(
                 }
             }
 
-            IconButton(onClick = { /* TODO: Show menu */ }) {
-                Icon(Icons.Default.MoreVert, contentDescription = "More options")
+            Box {
+                IconButton(onClick = { menuOpen = true }) {
+                    Icon(Icons.Default.MoreVert, contentDescription = "More options")
+                }
+                DropdownMenu(
+                    expanded = menuOpen,
+                    onDismissRequest = { menuOpen = false }
+                ) {
+                    if (isLocal) {
+                        if (details.syncEnabled) {
+                            DropdownMenuItem(
+                                text = { Text("Refresh from YouTube Music") },
+                                leadingIcon = {
+                                    Icon(Icons.Default.Refresh, contentDescription = null)
+                                },
+                                onClick = {
+                                    onRefreshFromRemote()
+                                    menuOpen = false
+                                }
+                            )
+                            DropdownMenuItem(
+                                text = { Text("Stop syncing (keep on YouTube Music)") },
+                                leadingIcon = {
+                                    Icon(Icons.Default.CloudOff, contentDescription = null)
+                                },
+                                onClick = {
+                                    onDisableSync(false)
+                                    menuOpen = false
+                                }
+                            )
+                            DropdownMenuItem(
+                                text = { Text("Stop syncing & delete on YouTube Music") },
+                                leadingIcon = {
+                                    Icon(Icons.Default.CloudOff, contentDescription = null)
+                                },
+                                onClick = {
+                                    onDisableSync(true)
+                                    menuOpen = false
+                                }
+                            )
+                        } else {
+                            DropdownMenuItem(
+                                text = { Text("Sync with YouTube Music") },
+                                leadingIcon = {
+                                    Icon(Icons.Default.CloudSync, contentDescription = null)
+                                },
+                                enabled = isSignedInToYouTubeMusic,
+                                onClick = {
+                                    onEnableSync()
+                                    menuOpen = false
+                                }
+                            )
+                        }
+                    }
+                }
             }
 
             Spacer(modifier = Modifier.weight(1f))

--- a/app/src/main/java/com/colux/libretune/ui/playlist/PlaylistViewModel.kt
+++ b/app/src/main/java/com/colux/libretune/ui/playlist/PlaylistViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.colux.libretune.data.model.PlaylistDetails
+import com.colux.libretune.data.remote.auth.YtMusicAuthRepository
 import com.colux.libretune.data.repository.PlaylistRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
@@ -16,6 +17,7 @@ import javax.inject.Inject
 @HiltViewModel
 class PlaylistDetailViewModel @Inject constructor(
     private val repository: PlaylistRepository,
+    authRepository: YtMusicAuthRepository,
     savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
@@ -29,6 +31,14 @@ class PlaylistDetailViewModel @Inject constructor(
         initialValue = false
     )
 
+    val isSignedInToYouTubeMusic: StateFlow<Boolean> = authRepository.state
+        .map { it != null }
+        .stateIn(
+            viewModelScope,
+            SharingStarted.WhileSubscribed(5000),
+            authRepository.current() != null
+        )
+
     val uiState: StateFlow<PlaylistUiState> =
         repository.getPlaylistDetails(playlistId)
             .map { details ->
@@ -38,11 +48,10 @@ class PlaylistDetailViewModel @Inject constructor(
             .stateIn(
                 scope = viewModelScope,
                 started = SharingStarted.WhileSubscribed(5000),
-                initialValue = PlaylistUiState.Loading // This is the ONLY time we use Loading
+                initialValue = PlaylistUiState.Loading
             )
 
     init {
-        // Trigger a refresh when the ViewModel is created
         viewModelScope.launch {
             repository.refreshPlaylistDetails(playlistId)
         }
@@ -63,7 +72,23 @@ class PlaylistDetailViewModel @Inject constructor(
         }
     }
 
+    fun enableYouTubeMusicSync() {
+        viewModelScope.launch {
+            repository.enableSyncForPlaylist(playlistId)
+        }
+    }
 
+    fun disableYouTubeMusicSync(alsoDeleteRemote: Boolean) {
+        viewModelScope.launch {
+            repository.disableSyncForPlaylist(playlistId, alsoDeleteRemote)
+        }
+    }
+
+    fun refreshFromYouTubeMusic() {
+        viewModelScope.launch {
+            repository.pullPlaylistFromYouTubeMusic(playlistId)
+        }
+    }
 }
 
 sealed interface PlaylistUiState {

--- a/app/src/main/java/com/colux/libretune/ui/sign_in/YouTubeMusicSignInScreen.kt
+++ b/app/src/main/java/com/colux/libretune/ui/sign_in/YouTubeMusicSignInScreen.kt
@@ -1,0 +1,148 @@
+package com.colux.libretune.ui.sign_in
+
+import android.annotation.SuppressLint
+import android.webkit.CookieManager
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavController
+
+private const val SIGN_IN_URL =
+    "https://accounts.google.com/ServiceLogin?continue=https://music.youtube.com/"
+private const val MUSIC_HOST = "music.youtube.com"
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun YouTubeMusicSignInScreen(
+    navController: NavController,
+    viewModel: YouTubeMusicSignInViewModel = hiltViewModel(),
+) {
+    val isSignedIn by viewModel.isSignedIn.collectAsState()
+    val cookieManager = remember { CookieManager.getInstance() }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(if (isSignedIn) "Signed in" else "Sign in to YouTube Music") },
+                navigationIcon = {
+                    IconButton(onClick = { navController.popBackStack() }) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                }
+            )
+        }
+    ) { inner ->
+        if (isSignedIn) {
+            SignedInPanel(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(inner),
+                onSignOut = viewModel::signOut
+            )
+        } else {
+            SignInWebView(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(inner),
+                cookieManager = cookieManager,
+                onCapture = { cookies -> viewModel.captureCookies(cookies) }
+            )
+        }
+    }
+}
+
+@Composable
+private fun SignedInPanel(
+    modifier: Modifier,
+    onSignOut: () -> Unit
+) {
+    Column(
+        modifier = modifier.padding(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Text(
+            "You're signed in to YouTube Music.",
+            style = MaterialTheme.typography.titleMedium
+        )
+        Spacer(modifier = Modifier.size(16.dp))
+        Text(
+            "Synced playlists you create from here will mirror to your YT Music account.",
+            style = MaterialTheme.typography.bodyMedium
+        )
+        Spacer(modifier = Modifier.size(32.dp))
+        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Center) {
+            androidx.compose.material3.TextButton(onClick = onSignOut) {
+                Text("Sign out")
+            }
+        }
+    }
+}
+
+@SuppressLint("SetJavaScriptEnabled")
+@Composable
+private fun SignInWebView(
+    modifier: Modifier,
+    cookieManager: CookieManager,
+    onCapture: (String) -> Unit,
+) {
+    AndroidView(
+        modifier = modifier,
+        factory = { context ->
+            cookieManager.setAcceptCookie(true)
+
+            WebView(context).apply {
+                settings.javaScriptEnabled = true
+                settings.domStorageEnabled = true
+                settings.userAgentString =
+                    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 " +
+                            "(KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+
+                cookieManager.setAcceptThirdPartyCookies(this, true)
+
+                webViewClient = object : WebViewClient() {
+                    override fun onPageFinished(view: WebView, url: String?) {
+                        if (url != null && url.contains(MUSIC_HOST)) {
+                            // Drain cookies for music.youtube.com — they're
+                            // only populated once Google bounces us back here.
+                            val cookies = cookieManager.getCookie("https://$MUSIC_HOST") ?: return
+                            if (cookies.contains("SAPISID") ||
+                                cookies.contains("__Secure-3PAPISID")
+                            ) {
+                                onCapture(cookies)
+                            }
+                        }
+                    }
+                }
+
+                loadUrl(SIGN_IN_URL)
+            }
+        }
+    )
+}
+

--- a/app/src/main/java/com/colux/libretune/ui/sign_in/YouTubeMusicSignInViewModel.kt
+++ b/app/src/main/java/com/colux/libretune/ui/sign_in/YouTubeMusicSignInViewModel.kt
@@ -1,0 +1,38 @@
+package com.colux.libretune.ui.sign_in
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.colux.libretune.data.remote.auth.YtMusicAuthRepository
+import com.colux.libretune.data.repository.YouTubeMusicSyncRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class YouTubeMusicSignInViewModel @Inject constructor(
+    private val authRepository: YtMusicAuthRepository,
+    private val syncRepository: YouTubeMusicSyncRepository,
+) : ViewModel() {
+
+    val isSignedIn: StateFlow<Boolean> = authRepository.state
+        .map { it != null }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), authRepository.current() != null)
+
+    fun captureCookies(cookieHeader: String) {
+        viewModelScope.launch {
+            runCatching { authRepository.signIn(cookieHeader) }
+                .onSuccess {
+                    // Drain any offline queue immediately after sign-in.
+                    syncRepository.flushPendingMutations()
+                }
+        }
+    }
+
+    fun signOut() {
+        authRepository.signOut()
+    }
+}

--- a/libretune-extractor/src/main/java/com/coluzziandrea/libretune_extractor/LibreTuneExtractor.kt
+++ b/libretune-extractor/src/main/java/com/coluzziandrea/libretune_extractor/LibreTuneExtractor.kt
@@ -1,5 +1,6 @@
 package com.coluzziandrea.libretune_extractor
 
+import com.coluzziandrea.libretune_extractor.auth.AuthProvider
 import com.coluzziandrea.libretune_extractor.client.LibreClient
 import com.coluzziandrea.libretune_extractor.model.ArtistDetails
 import com.coluzziandrea.libretune_extractor.model.Discography
@@ -15,6 +16,7 @@ import com.coluzziandrea.libretune_extractor.parser.mapper.toDiscography
 import com.coluzziandrea.libretune_extractor.parser.mapper.toGenreMoodCategory
 import com.coluzziandrea.libretune_extractor.parser.mapper.toGenresMoods
 import com.coluzziandrea.libretune_extractor.parser.toSearchSuggestions
+import com.coluzziandrea.libretune_extractor.sync.YouTubeMusicSyncClient
 import io.ktor.client.HttpClient
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
@@ -24,7 +26,8 @@ import javax.inject.Singleton
 
 @Singleton
 class LibreTuneExtractor @Inject constructor(
-    httpClient: HttpClient
+    httpClient: HttpClient,
+    authProvider: AuthProvider = AuthProvider.Anonymous
 ) {
 
     companion object {
@@ -32,7 +35,9 @@ class LibreTuneExtractor @Inject constructor(
         const val GENRE_MOOD_CATEGORY_BROWSE_ID = "FEmusic_moods_and_genres_category"
     }
 
-    private val client = LibreClient(httpClient)
+    private val client = LibreClient(httpClient, authProvider)
+
+    val sync: YouTubeMusicSyncClient = YouTubeMusicSyncClient(client)
 
 
     suspend fun playlist(playlistId: String): PlaylistDetails? {

--- a/libretune-extractor/src/main/java/com/coluzziandrea/libretune_extractor/auth/AuthProvider.kt
+++ b/libretune-extractor/src/main/java/com/coluzziandrea/libretune_extractor/auth/AuthProvider.kt
@@ -1,0 +1,16 @@
+package com.coluzziandrea.libretune_extractor.auth
+
+/**
+ * Supplies the current YouTube Music auth state to the network client.
+ *
+ * Implementations live in the app module (cookie persistence + WebView capture).
+ * Returning `null` means the user is signed out — the client falls back to
+ * anonymous requests, which is fine for read-only browse/search.
+ */
+fun interface AuthProvider {
+    fun current(): YtmAuthState?
+
+    object Anonymous : AuthProvider {
+        override fun current(): YtmAuthState? = null
+    }
+}

--- a/libretune-extractor/src/main/java/com/coluzziandrea/libretune_extractor/auth/SapisidHash.kt
+++ b/libretune-extractor/src/main/java/com/coluzziandrea/libretune_extractor/auth/SapisidHash.kt
@@ -1,0 +1,24 @@
+package com.coluzziandrea.libretune_extractor.auth
+
+import java.security.MessageDigest
+
+/**
+ * Builds the `Authorization: SAPISIDHASH <timestamp>_<sha1>` value that
+ * Google's "G-style" web authentication expects.
+ *
+ * Reference: https://stackoverflow.com/a/32065323 — the same scheme YT, YT Music
+ * and other Google products use for SAPISID-cookie based auth.
+ */
+object SapisidHash {
+
+    fun authorizationHeader(
+        sapisid: String,
+        origin: String = "https://music.youtube.com",
+        timestampSeconds: Long = System.currentTimeMillis() / 1000
+    ): String {
+        val payload = "$timestampSeconds $sapisid $origin"
+        val digest = MessageDigest.getInstance("SHA-1").digest(payload.toByteArray(Charsets.UTF_8))
+        val hex = digest.joinToString("") { "%02x".format(it) }
+        return "SAPISIDHASH ${timestampSeconds}_$hex"
+    }
+}

--- a/libretune-extractor/src/main/java/com/coluzziandrea/libretune_extractor/auth/YtmAuthState.kt
+++ b/libretune-extractor/src/main/java/com/coluzziandrea/libretune_extractor/auth/YtmAuthState.kt
@@ -1,0 +1,31 @@
+package com.coluzziandrea.libretune_extractor.auth
+
+/**
+ * Snapshot of the credentials needed to make authenticated YouTube Music
+ * innertube requests on behalf of a signed-in user.
+ *
+ * Cookies must include either `SAPISID` or `__Secure-3PAPISID` — those are the
+ * values hashed into the `Authorization: SAPISIDHASH …` header that YT Music
+ * verifies on write endpoints.
+ */
+data class YtmAuthState(
+    val cookieHeader: String,
+    val sapisid: String,
+    val origin: String = "https://music.youtube.com",
+    val userAgent: String = DEFAULT_USER_AGENT,
+    val visitorData: String? = null
+) {
+    companion object {
+        const val DEFAULT_USER_AGENT =
+            "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+
+        fun extractSapisid(cookieHeader: String): String? {
+            val parts = cookieHeader.split(';').map { it.trim() }
+            val sapisid = parts.firstOrNull { it.startsWith("SAPISID=") }
+                ?.removePrefix("SAPISID=")
+            if (!sapisid.isNullOrBlank()) return sapisid
+            return parts.firstOrNull { it.startsWith("__Secure-3PAPISID=") }
+                ?.removePrefix("__Secure-3PAPISID=")
+        }
+    }
+}

--- a/libretune-extractor/src/main/java/com/coluzziandrea/libretune_extractor/client/LibreClient.kt
+++ b/libretune-extractor/src/main/java/com/coluzziandrea/libretune_extractor/client/LibreClient.kt
@@ -1,11 +1,21 @@
 package com.coluzziandrea.libretune_extractor.client
 
+import com.coluzziandrea.libretune_extractor.auth.AuthProvider
+import com.coluzziandrea.libretune_extractor.auth.SapisidHash
+import com.coluzziandrea.libretune_extractor.auth.YtmAuthState
 import com.coluzziandrea.libretune_extractor.client.request.BrowseRequest
 import com.coluzziandrea.libretune_extractor.client.request.Client
 import com.coluzziandrea.libretune_extractor.client.request.Context
+import com.coluzziandrea.libretune_extractor.client.request.CreatePlaylistRequest
+import com.coluzziandrea.libretune_extractor.client.request.DeletePlaylistRequest
+import com.coluzziandrea.libretune_extractor.client.request.EditPlaylistAction
+import com.coluzziandrea.libretune_extractor.client.request.EditPlaylistRequest
 import com.coluzziandrea.libretune_extractor.client.request.SearchRequest
 import com.coluzziandrea.libretune_extractor.client.request.SearchSuggestionRequest
 import com.coluzziandrea.libretune_extractor.client.response.BrowseData
+import com.coluzziandrea.libretune_extractor.client.response.CreatePlaylistResponse
+import com.coluzziandrea.libretune_extractor.client.response.DeletePlaylistResponse
+import com.coluzziandrea.libretune_extractor.client.response.EditPlaylistResponse
 import com.coluzziandrea.libretune_extractor.client.response.MultipleContentBrowseData
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
@@ -15,9 +25,11 @@ import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.contentType
+import kotlinx.serialization.json.JsonElement
 
 class LibreClient(
-    private val client: HttpClient
+    private val client: HttpClient,
+    private val authProvider: AuthProvider = AuthProvider.Anonymous
 ) {
 
     companion object {
@@ -25,6 +37,7 @@ class LibreClient(
 
         const val CLIENT_NAME = "WEB_REMIX"
         const val CLIENT_VERSION = "1.20250827.05.00"
+        const val CLIENT_ID_HEADER_VALUE = "67"
     }
 
 
@@ -86,15 +99,105 @@ class LibreClient(
         return res
     }
 
+    /**
+     * Returns the raw JSON tree for a browse call — used by the sync layer to
+     * pull `playlistItemData.playlistSetVideoId` values that the typed response
+     * classes don't model.
+     */
+    suspend fun browseRaw(browseId: String, params: String? = null): JsonElement {
+        return client.post("$BASE_URL/browse?prettyPrint=false") {
+            contentType(ContentType.Application.Json)
+            setHeaders()
+            setBody(
+                BrowseRequest(
+                    browseId = browseId,
+                    context = getContext(),
+                    params
+                )
+            )
+        }.body<JsonElement>()
+    }
+
+    suspend fun editPlaylist(
+        playlistId: String,
+        actions: List<EditPlaylistAction>
+    ): EditPlaylistResponse {
+        requireAuthenticated("editPlaylist")
+        return client.post("$BASE_URL/browse/edit_playlist?prettyPrint=false") {
+            contentType(ContentType.Application.Json)
+            setHeaders()
+            setBody(
+                EditPlaylistRequest(
+                    playlistId = playlistId,
+                    actions = actions,
+                    context = getContext()
+                )
+            )
+        }.body<EditPlaylistResponse>()
+    }
+
+    suspend fun createPlaylist(
+        title: String,
+        description: String = "",
+        privacyStatus: String = "PRIVATE",
+        videoIds: List<String> = emptyList()
+    ): CreatePlaylistResponse {
+        requireAuthenticated("createPlaylist")
+        return client.post("$BASE_URL/playlist/create?prettyPrint=false") {
+            contentType(ContentType.Application.Json)
+            setHeaders()
+            setBody(
+                CreatePlaylistRequest(
+                    title = title,
+                    description = description,
+                    privacyStatus = privacyStatus,
+                    videoIds = videoIds,
+                    context = getContext()
+                )
+            )
+        }.body<CreatePlaylistResponse>()
+    }
+
+    suspend fun deletePlaylist(playlistId: String): DeletePlaylistResponse {
+        requireAuthenticated("deletePlaylist")
+        return client.post("$BASE_URL/playlist/delete?prettyPrint=false") {
+            contentType(ContentType.Application.Json)
+            setHeaders()
+            setBody(
+                DeletePlaylistRequest(
+                    playlistId = playlistId,
+                    context = getContext()
+                )
+            )
+        }.body<DeletePlaylistResponse>()
+    }
+
+    private fun requireAuthenticated(operation: String) {
+        if (authProvider.current() == null) {
+            throw IllegalStateException(
+                "$operation requires the user to be signed in to YouTube Music"
+            )
+        }
+    }
+
     private fun HttpRequestBuilder.setHeaders() {
-        header(
-            "User-Agent",
-            "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
-        )
+        val auth = authProvider.current()
+        header("User-Agent", auth?.userAgent ?: YtmAuthState.DEFAULT_USER_AGENT)
         header("Accept-Language", "en-US,en;q=0.9")
         header(
             "Accept",
             "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8"
         )
+        header("X-YouTube-Client-Name", CLIENT_ID_HEADER_VALUE)
+        header("X-YouTube-Client-Version", CLIENT_VERSION)
+
+        if (auth != null) {
+            header("Cookie", auth.cookieHeader)
+            header("Origin", auth.origin)
+            header("X-Origin", auth.origin)
+            header("X-Goog-AuthUser", "0")
+            header("Authorization", SapisidHash.authorizationHeader(auth.sapisid, auth.origin))
+            auth.visitorData?.let { header("X-Goog-Visitor-Id", it) }
+        }
     }
 }

--- a/libretune-extractor/src/main/java/com/coluzziandrea/libretune_extractor/client/request/CreatePlaylistRequest.kt
+++ b/libretune-extractor/src/main/java/com/coluzziandrea/libretune_extractor/client/request/CreatePlaylistRequest.kt
@@ -1,0 +1,18 @@
+package com.coluzziandrea.libretune_extractor.client.request
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CreatePlaylistRequest(
+    val title: String,
+    val description: String = "",
+    val privacyStatus: String = "PRIVATE",
+    val videoIds: List<String> = emptyList(),
+    val context: Context
+)
+
+@Serializable
+data class DeletePlaylistRequest(
+    val playlistId: String,
+    val context: Context
+)

--- a/libretune-extractor/src/main/java/com/coluzziandrea/libretune_extractor/client/request/EditPlaylistRequest.kt
+++ b/libretune-extractor/src/main/java/com/coluzziandrea/libretune_extractor/client/request/EditPlaylistRequest.kt
@@ -1,0 +1,31 @@
+package com.coluzziandrea.libretune_extractor.client.request
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class EditPlaylistAction(
+    val action: String,
+    val addedVideoId: String? = null,
+    val removedVideoId: String? = null,
+    val setVideoId: String? = null
+) {
+    companion object {
+        fun add(videoId: String) = EditPlaylistAction(
+            action = "ACTION_ADD_VIDEO",
+            addedVideoId = videoId
+        )
+
+        fun remove(videoId: String, setVideoId: String) = EditPlaylistAction(
+            action = "ACTION_REMOVE_VIDEO",
+            removedVideoId = videoId,
+            setVideoId = setVideoId
+        )
+    }
+}
+
+@Serializable
+data class EditPlaylistRequest(
+    val playlistId: String,
+    val actions: List<EditPlaylistAction>,
+    val context: Context
+)

--- a/libretune-extractor/src/main/java/com/coluzziandrea/libretune_extractor/client/response/EditPlaylistResponse.kt
+++ b/libretune-extractor/src/main/java/com/coluzziandrea/libretune_extractor/client/response/EditPlaylistResponse.kt
@@ -1,0 +1,32 @@
+package com.coluzziandrea.libretune_extractor.client.response
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class EditPlaylistResponse(
+    val status: String? = null,
+    val playlistEditResults: List<PlaylistEditResult> = emptyList()
+)
+
+@Serializable
+data class PlaylistEditResult(
+    val playlistEditVideoAddedResultData: PlaylistEditVideoAddedResultData? = null
+)
+
+@Serializable
+data class PlaylistEditVideoAddedResultData(
+    val videoId: String? = null,
+    val setVideoId: String? = null
+)
+
+@Serializable
+data class CreatePlaylistResponse(
+    val playlistId: String? = null,
+    val status: String? = null
+)
+
+@Serializable
+data class DeletePlaylistResponse(
+    val status: String? = null,
+    val command: kotlinx.serialization.json.JsonElement? = null
+)

--- a/libretune-extractor/src/main/java/com/coluzziandrea/libretune_extractor/sync/SyncedPlaylistItem.kt
+++ b/libretune-extractor/src/main/java/com/coluzziandrea/libretune_extractor/sync/SyncedPlaylistItem.kt
@@ -1,0 +1,28 @@
+package com.coluzziandrea.libretune_extractor.sync
+
+/**
+ * A single track inside a YouTube Music playlist as returned by the
+ * authenticated `browse VL<playlistId>` call.
+ *
+ * `setVideoId` is the unique identifier of *this occurrence* inside the
+ * playlist — you need it (not the videoId) to ask YT Music to remove the
+ * track, since a playlist can contain the same video multiple times.
+ */
+data class SyncedPlaylistItem(
+    val videoId: String,
+    val setVideoId: String?,
+    val title: String?,
+    val artistNames: String?,
+    val albumName: String?
+)
+
+data class RemotePlaylistSnapshot(
+    val playlistId: String,
+    val title: String?,
+    val items: List<SyncedPlaylistItem>
+)
+
+data class LibraryPlaylistSummary(
+    val playlistId: String,
+    val title: String
+)

--- a/libretune-extractor/src/main/java/com/coluzziandrea/libretune_extractor/sync/YouTubeMusicSyncClient.kt
+++ b/libretune-extractor/src/main/java/com/coluzziandrea/libretune_extractor/sync/YouTubeMusicSyncClient.kt
@@ -1,0 +1,198 @@
+package com.coluzziandrea.libretune_extractor.sync
+
+import com.coluzziandrea.libretune_extractor.client.LibreClient
+import com.coluzziandrea.libretune_extractor.client.request.EditPlaylistAction
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * Authenticated playlist mutations against YouTube Music.
+ *
+ * Every method here assumes the [LibreClient] was constructed with a real
+ * [com.coluzziandrea.libretune_extractor.auth.AuthProvider]; the client will
+ * throw `IllegalStateException` if the user isn't signed in.
+ */
+class YouTubeMusicSyncClient(
+    private val client: LibreClient
+) {
+
+    /**
+     * Creates a new playlist owned by the signed-in user. Returns the YT Music
+     * playlist ID (something like `PLxxxxxxx`).
+     */
+    suspend fun createPlaylist(
+        title: String,
+        description: String = "",
+        privacyStatus: String = "PRIVATE",
+        seedVideoIds: List<String> = emptyList()
+    ): String? {
+        val resp = client.createPlaylist(title, description, privacyStatus, seedVideoIds)
+        return resp.playlistId
+    }
+
+    suspend fun deletePlaylist(playlistId: String) {
+        client.deletePlaylist(playlistId)
+    }
+
+    /**
+     * Adds one video to a playlist and returns the per-occurrence `setVideoId`
+     * that the caller must persist to be able to remove it later.
+     */
+    suspend fun addToPlaylist(playlistId: String, videoId: String): String? {
+        val resp = client.editPlaylist(
+            playlistId = playlistId,
+            actions = listOf(EditPlaylistAction.add(videoId))
+        )
+        return resp.playlistEditResults
+            .firstNotNullOfOrNull { it.playlistEditVideoAddedResultData?.setVideoId }
+    }
+
+    suspend fun removeFromPlaylist(
+        playlistId: String,
+        videoId: String,
+        setVideoId: String
+    ) {
+        client.editPlaylist(
+            playlistId = playlistId,
+            actions = listOf(EditPlaylistAction.remove(videoId, setVideoId))
+        )
+    }
+
+    /**
+     * Pulls every item of a YT Music playlist, including the `setVideoId`s. Use
+     * `PL…` (not `VL…`) as the playlist ID — the client adds the `VL` prefix
+     * for the browse call internally.
+     */
+    suspend fun fetchPlaylistItems(playlistId: String): RemotePlaylistSnapshot {
+        val browseId = if (playlistId.startsWith("VL")) playlistId else "VL$playlistId"
+        val raw = client.browseRaw(browseId)
+        val items = mutableListOf<SyncedPlaylistItem>()
+        collectPlaylistItems(raw, items)
+        val title = findFirstTitleString(raw)
+        return RemotePlaylistSnapshot(
+            playlistId = playlistId.removePrefix("VL"),
+            title = title,
+            items = items
+        )
+    }
+
+    /**
+     * Lists every playlist visible in the signed-in user's library
+     * ("Your Library → Playlists" on the YT Music web UI).
+     */
+    suspend fun fetchLibraryPlaylists(): List<LibraryPlaylistSummary> {
+        val raw = client.browseRaw("FEmusic_liked_playlists")
+        val out = mutableListOf<LibraryPlaylistSummary>()
+        collectLibraryPlaylists(raw, out)
+        return out
+    }
+
+    private fun collectPlaylistItems(
+        node: JsonElement,
+        out: MutableList<SyncedPlaylistItem>
+    ) {
+        when (node) {
+            is JsonObject -> {
+                val renderer = node["musicResponsiveListItemRenderer"]
+                if (renderer is JsonObject) {
+                    parseMusicResponsiveListItem(renderer)?.let(out::add)
+                }
+                node.values.forEach { collectPlaylistItems(it, out) }
+            }
+
+            is JsonArray -> node.forEach { collectPlaylistItems(it, out) }
+            else -> Unit
+        }
+    }
+
+    private fun parseMusicResponsiveListItem(renderer: JsonObject): SyncedPlaylistItem? {
+        val itemData = renderer["playlistItemData"] as? JsonObject ?: return null
+        val videoId = itemData["videoId"]?.jsonPrimitive?.contentOrNull ?: return null
+        val setVideoId = itemData["playlistSetVideoId"]?.jsonPrimitive?.contentOrNull
+
+        val flexColumns = renderer["flexColumns"] as? JsonArray
+        val titles = flexColumns?.mapNotNull { firstRunText(it) }.orEmpty()
+
+        return SyncedPlaylistItem(
+            videoId = videoId,
+            setVideoId = setVideoId,
+            title = titles.getOrNull(0),
+            artistNames = titles.getOrNull(1),
+            albumName = titles.getOrNull(2)
+        )
+    }
+
+    private fun firstRunText(column: JsonElement): String? {
+        if (column !is JsonObject) return null
+        val renderer = column["musicResponsiveListItemFlexColumnRenderer"] as? JsonObject
+            ?: return null
+        val text = renderer["text"] as? JsonObject ?: return null
+        val runs = text["runs"] as? JsonArray ?: return null
+        return runs.firstNotNullOfOrNull {
+            (it as? JsonObject)?.get("text")?.jsonPrimitive?.contentOrNull
+        }
+    }
+
+    private fun collectLibraryPlaylists(
+        node: JsonElement,
+        out: MutableList<LibraryPlaylistSummary>
+    ) {
+        when (node) {
+            is JsonObject -> {
+                val twoRow = node["musicTwoRowItemRenderer"] as? JsonObject
+                if (twoRow != null) {
+                    parseTwoRowPlaylistEntry(twoRow)?.let(out::add)
+                }
+                node.values.forEach { collectLibraryPlaylists(it, out) }
+            }
+
+            is JsonArray -> node.forEach { collectLibraryPlaylists(it, out) }
+            else -> Unit
+        }
+    }
+
+    private fun parseTwoRowPlaylistEntry(renderer: JsonObject): LibraryPlaylistSummary? {
+        val nav = renderer["navigationEndpoint"] as? JsonObject ?: return null
+        val browse = nav["browseEndpoint"] as? JsonObject ?: return null
+        val browseId = browse["browseId"]?.jsonPrimitive?.contentOrNull ?: return null
+        // YT Music prefixes playlist browse IDs with "VL".
+        if (!browseId.startsWith("VL")) return null
+
+        val title = (renderer["title"] as? JsonObject)
+            ?.let { (it["runs"] as? JsonArray)?.firstOrNull() }
+            ?.let { (it as? JsonObject)?.get("text")?.jsonPrimitive?.contentOrNull }
+            ?: return null
+
+        return LibraryPlaylistSummary(
+            playlistId = browseId.removePrefix("VL"),
+            title = title
+        )
+    }
+
+    private fun findFirstTitleString(node: JsonElement): String? {
+        if (node is JsonObject) {
+            val header = node["musicDetailHeaderRenderer"] as? JsonObject
+                ?: node["musicEditablePlaylistDetailHeaderRenderer"] as? JsonObject
+                ?: node["musicResponsiveHeaderRenderer"] as? JsonObject
+            if (header != null) {
+                val title = (header["title"] as? JsonObject)
+                    ?.let { (it["runs"] as? JsonArray)?.firstOrNull() }
+                    ?.let { (it as? JsonObject)?.get("text")?.jsonPrimitive?.contentOrNull }
+                if (!title.isNullOrBlank()) return title
+            }
+            for (v in node.values) {
+                val t = findFirstTitleString(v)
+                if (!t.isNullOrBlank()) return t
+            }
+        } else if (node is JsonArray) {
+            for (v in node) {
+                val t = findFirstTitleString(v)
+                if (!t.isNullOrBlank()) return t
+            }
+        }
+        return null
+    }
+}


### PR DESCRIPTION
Adds opt-in sync between local playlists and the signed-in user's
YouTube Music account. Sign in via the new drawer entry, toggle "Sync
with YouTube Music" on a playlist, and add/remove songs — every change
mirrors over the innertube API. The playlist menu has a "Refresh from
YouTube Music" action that pulls remote changes back into the local DB.

- libretune-extractor: AuthProvider + SAPISIDHASH auth wiring on the
  existing innertube client, plus a YouTubeMusicSyncClient that exposes
  create/delete playlist and add/remove track endpoints.
- app: a YtMusicAuthRepository captures cookies via a WebView, a
  YouTubeMusicSyncRepository orchestrates push/pull with PENDING_ADD /
  PENDING_REMOVE bookkeeping so offline edits aren't lost, and Room
  schema bumps to v2 with remotePlaylistId / syncEnabled on playlists
  and setVideoId / syncState on the playlist-song join.