### PR TITLE
Two-way YouTube Music playlist sync

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -124,6 +124,10 @@ dependencies {
 
     implementation(libs.androidx.media3.session)
 
+    // Needed to strip the X-Requested-With header so Google's login page
+    // doesn't reject the embedded WebView as an "insecure browser".
+    implementation(libs.androidx.webkit)
+
 
     implementation(project(":libretune-extractor"))
 

--- a/app/src/main/java/com/colux/libretune/ui/sign_in/YouTubeMusicSignInScreen.kt
+++ b/app/src/main/java/com/colux/libretune/ui/sign_in/YouTubeMusicSignInScreen.kt
@@ -10,31 +10,48 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
+import androidx.webkit.WebSettingsCompat
+import androidx.webkit.WebViewFeature
 
 private const val SIGN_IN_URL =
     "https://accounts.google.com/ServiceLogin?continue=https://music.youtube.com/"
 private const val MUSIC_HOST = "music.youtube.com"
+
+// A plain desktop Chrome UA — crucially without the Android WebView "; wv"
+// marker that Google uses to flag embedded browsers as insecure.
+private const val DESKTOP_USER_AGENT =
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 " +
+        "(KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -44,6 +61,7 @@ fun YouTubeMusicSignInScreen(
 ) {
     val isSignedIn by viewModel.isSignedIn.collectAsState()
     val cookieManager = remember { CookieManager.getInstance() }
+    var manualEntry by remember { mutableStateOf(false) }
 
     Scaffold(
         topBar = {
@@ -57,20 +75,27 @@ fun YouTubeMusicSignInScreen(
             )
         }
     ) { inner ->
-        if (isSignedIn) {
-            SignedInPanel(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(inner),
+        val contentModifier = Modifier
+            .fillMaxSize()
+            .padding(inner)
+
+        when {
+            isSignedIn -> SignedInPanel(
+                modifier = contentModifier,
                 onSignOut = viewModel::signOut
             )
-        } else {
-            SignInWebView(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(inner),
+
+            manualEntry -> ManualCookieEntry(
+                modifier = contentModifier,
+                onSubmit = { viewModel.captureCookies(it) },
+                onUseWebView = { manualEntry = false }
+            )
+
+            else -> SignInWebView(
+                modifier = contentModifier,
                 cookieManager = cookieManager,
-                onCapture = { cookies -> viewModel.captureCookies(cookies) }
+                onCapture = { cookies -> viewModel.captureCookies(cookies) },
+                onUseManualEntry = { manualEntry = true }
             )
         }
     }
@@ -97,52 +122,127 @@ private fun SignedInPanel(
         )
         Spacer(modifier = Modifier.size(32.dp))
         Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Center) {
-            androidx.compose.material3.TextButton(onClick = onSignOut) {
+            TextButton(onClick = onSignOut) {
                 Text("Sign out")
             }
         }
     }
 }
 
-@SuppressLint("SetJavaScriptEnabled")
+@SuppressLint("SetJavaScriptEnabled", "RequiresFeature")
 @Composable
 private fun SignInWebView(
     modifier: Modifier,
     cookieManager: CookieManager,
     onCapture: (String) -> Unit,
+    onUseManualEntry: () -> Unit,
 ) {
-    AndroidView(
-        modifier = modifier,
-        factory = { context ->
-            cookieManager.setAcceptCookie(true)
+    Column(modifier = modifier) {
+        AndroidView(
+            modifier = Modifier.weight(1f),
+            factory = { context ->
+                cookieManager.setAcceptCookie(true)
 
-            WebView(context).apply {
-                settings.javaScriptEnabled = true
-                settings.domStorageEnabled = true
-                settings.userAgentString =
-                    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 " +
-                            "(KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+                WebView(context).apply {
+                    settings.javaScriptEnabled = true
+                    settings.domStorageEnabled = true
+                    settings.userAgentString = DESKTOP_USER_AGENT
 
-                cookieManager.setAcceptThirdPartyCookies(this, true)
+                    // The header that gives away an embedded WebView. Removing
+                    // it for all origins is what lets Google's login succeed.
+                    if (WebViewFeature.isFeatureSupported(
+                            WebViewFeature.REQUESTED_WITH_HEADER_ALLOW_LIST
+                        )
+                    ) {
+                        WebSettingsCompat.setRequestedWithHeaderOriginAllowList(
+                            settings,
+                            emptySet()
+                        )
+                    }
 
-                webViewClient = object : WebViewClient() {
-                    override fun onPageFinished(view: WebView, url: String?) {
-                        if (url != null && url.contains(MUSIC_HOST)) {
-                            // Drain cookies for music.youtube.com — they're
-                            // only populated once Google bounces us back here.
-                            val cookies = cookieManager.getCookie("https://$MUSIC_HOST") ?: return
-                            if (cookies.contains("SAPISID") ||
-                                cookies.contains("__Secure-3PAPISID")
-                            ) {
-                                onCapture(cookies)
+                    cookieManager.setAcceptThirdPartyCookies(this, true)
+
+                    webViewClient = object : WebViewClient() {
+                        override fun onPageFinished(view: WebView, url: String?) {
+                            if (url != null && url.contains(MUSIC_HOST)) {
+                                // Cookies for music.youtube.com only appear once
+                                // Google bounces us back after a successful login.
+                                val cookies =
+                                    cookieManager.getCookie("https://$MUSIC_HOST") ?: return
+                                if (cookies.contains("SAPISID") ||
+                                    cookies.contains("__Secure-3PAPISID")
+                                ) {
+                                    onCapture(cookies)
+                                }
                             }
                         }
                     }
-                }
 
-                loadUrl(SIGN_IN_URL)
+                    loadUrl(SIGN_IN_URL)
+                }
+            }
+        )
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp),
+            horizontalArrangement = Arrangement.Center
+        ) {
+            TextButton(onClick = onUseManualEntry) {
+                Text("Sign-in blocked? Paste cookies manually")
             }
         }
-    )
+    }
 }
 
+@Composable
+private fun ManualCookieEntry(
+    modifier: Modifier,
+    onSubmit: (String) -> Unit,
+    onUseWebView: () -> Unit,
+) {
+    var text by remember { mutableStateOf("") }
+    Column(
+        modifier = modifier
+            .verticalScroll(rememberScrollState())
+            .padding(24.dp)
+    ) {
+        Text("Paste your YouTube Music cookie", style = MaterialTheme.typography.titleMedium)
+        Spacer(modifier = Modifier.size(8.dp))
+        Text(
+            "On a desktop browser, sign in at music.youtube.com, open the developer " +
+                "tools (F12) → Network tab, click any request to music.youtube.com, " +
+                "and copy the full value of the \"cookie\" request header. It must " +
+                "contain SAPISID.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
+        )
+        Spacer(modifier = Modifier.size(16.dp))
+        OutlinedTextField(
+            value = text,
+            onValueChange = { text = it },
+            label = { Text("Cookie header") },
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(160.dp),
+            maxLines = 8
+        )
+        Spacer(modifier = Modifier.size(16.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.End,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            TextButton(onClick = onUseWebView) {
+                Text("Use sign-in page", overflow = TextOverflow.Ellipsis)
+            }
+            Spacer(modifier = Modifier.size(8.dp))
+            Button(
+                onClick = { onSubmit(text.trim()) },
+                enabled = text.contains("SAPISID")
+            ) {
+                Text("Save")
+            }
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,6 +50,7 @@ material = "1.12.0"
 foundation = "1.9.0"
 material3 = "1.3.2"
 animation = "1.9.0"
+webkit = "1.11.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -114,6 +115,7 @@ material = { group = "com.google.android.material", name = "material", version.r
 androidx-foundation = { group = "androidx.compose.foundation", name = "foundation", version.ref = "foundation" }
 material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "material3" }
 androidx-animation = { group = "androidx.compose.animation", name = "animation", version.ref = "animation" }
+androidx-webkit = { group = "androidx.webkit", name = "webkit", version.ref = "webkit" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary

Adds opt-in two-way sync between local playlists and the signed-in user's YouTube Music account. Once signed in, the user can mark a local playlist as synced; adding/removing a song mirrors the change to YT Music, and a "Refresh from YouTube Music" action pulls remote changes back into the local DB.

Auth uses the innertube cookie approach (SAPISIDHASH), matching the app's existing anonymous innertube architecture. Sync is **off by default** and requires an explicit sign-in, preserving the anonymous-by-default privacy stance.

### `libretune-extractor`
- `auth/` — `YtmAuthState`, `AuthProvider` interface, and `SapisidHash` (SHA-1 signing for the `Authorization: SAPISIDHASH …` header YT Music verifies on writes).
- `client/LibreClient.kt` — injects `Cookie` / `Authorization` / `X-Origin` / `X-Goog-AuthUser` headers when signed in; adds `editPlaylist` / `createPlaylist` / `deletePlaylist` / `browseRaw` endpoints.
- `sync/YouTubeMusicSyncClient.kt` — high-level API: create/delete playlist, add/remove track (returns the per-occurrence `setVideoId` needed for removal), fetch playlist items, fetch library playlists.

### `app`
- `data/remote/auth/` — `YtMusicAuthRepository` (implements `AuthProvider`) + `YtMusicCredentialsStore` (cookie persistence). Bound via `di/AuthModule.kt`.
- `data/repository/YouTubeMusicSyncRepository.kt` — orchestrates push/pull. Local DB writes never block on the network; failed remote mutations are parked as `PENDING_ADD` / `PENDING_REMOVE` and retried on the next pull / `flushPendingMutations`.
- Room schema **v1 → v2** migration: `remotePlaylistId` + `syncEnabled` on `playlists`, `setVideoId` + `syncState` on the playlist-song join.
- `PlaylistRepository` / `SongRepository` wired so add/remove and refresh automatically mirror for synced playlists (no-op otherwise).
- UI: drawer "YouTube Music" entry → WebView sign-in screen, "Sync with YouTube Music" toggle on create-playlist, cloud indicator + sync menu on playlist detail.

### Google WebView login block
Google rejects logins in embedded WebViews. The sign-in screen strips the `X-Requested-With` header via `androidx.webkit`'s origin allowlist and uses a desktop Chrome user-agent (no `; wv` marker), with a manual cookie-paste fallback for devices lacking the WebView feature.

## Test plan
- [ ] Project builds (`./gradlew assembleDebug`) — **not verified in CI sandbox; no Android SDK available**
- [ ] Sign in via the drawer → YouTube Music entry without hitting Google's "browser not secure" block
- [ ] Create a playlist with "Sync with YouTube Music" enabled → playlist appears on music.youtube.com
- [ ] Add a song locally → it appears in the YT Music playlist
- [ ] Remove a song locally → it disappears from the YT Music playlist
- [ ] Add/remove a song on music.youtube.com → "Refresh from YouTube Music" reflects it locally
- [ ] Room migration from an existing v1 install (no data loss / crash)
- [ ] Offline edit then reconnect → pending changes flush on next sign-in/refresh

> ⚠️ This feature accesses YouTube Music's private innertube endpoints with the user's credentials — review the project's stance on ToS implications before merging.

---
_Generated by [Claude Code](https://claude.ai/code/session_019njevDJ64RERM1dnsPMPoE)_